### PR TITLE
Validate extract1d extension presence

### DIFF
--- a/chromatic/rainbows/readers/atoca.py
+++ b/chromatic/rainbows/readers/atoca.py
@@ -82,6 +82,8 @@ def from_atoca(rainbow, filepath, order=1):
     # Loop over all input filenames.
     for i_file, f in enumerate(tqdm(filenames, leave=False)):
         hdu_list = fits.open(f)
+        # Add a flag to check if extract1d extension exists.
+        has_extract1d = False
 
         # Useful initializations for later.
         quantities = {}
@@ -100,6 +102,8 @@ def from_atoca(rainbow, filepath, order=1):
                 continue
             if hdu_list[i].header["SPORDER"] != order:
                 continue
+            # If we find a good extension, flip the flag.
+            has_extract1d = True
             # Unpack each of the data types stored in each extension.
             # This includes the usual wavelength, flux, and error, but also
             # many other things which may or may not be useful (or even
@@ -112,6 +116,12 @@ def from_atoca(rainbow, filepath, order=1):
                         [quantities[quantity], hdu_list[i].data[quantity]]
                     )
             first_time = False
+
+    # Check if any extract1d extensions were found.
+    if not has_extract1d:
+        raise ValueError(
+            "No EXTRACT1D extensions found for order {} in {}.".format(order, f)
+        )
 
     # Pack all the above data into a Rainbow object.
     for quantity in quantities.keys():

--- a/chromatic/rainbows/readers/x1dints.py
+++ b/chromatic/rainbows/readers/x1dints.py
@@ -208,6 +208,10 @@ def from_x1dints(rainbow, filepath, order=None, **kw):
         # open this fits file
         with fits.open(f) as hdu:
 
+            # Check if an EXTRACT1D extension exists before we do anything else.
+            if "EXTRACT1D" not in hdu:
+                raise ValueError(f"No EXTRACT1D extension found in {f}.")
+
             # if this is the first one, populate the shared stuff
             if i_file == 0:
 


### PR DESCRIPTION
Add early validation for the `EXTRACT1D` FITS extension to prevent errors from files without extractable spectra.

---
<a href="https://cursor.com/background-agent?bcId=bc-632e1cb1-88be-4175-b11b-957afbfe91c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-632e1cb1-88be-4175-b11b-957afbfe91c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

